### PR TITLE
[DEFECT] Signage crashes when a user chooses a video or image for a slide background/foreground but doesn't upload anything.

### DIFF
--- a/app/controllers/slides_controller.rb
+++ b/app/controllers/slides_controller.rb
@@ -179,13 +179,11 @@ class SlidesController < ApplicationController
         :background,
         :background_type,
         :background_sizing,
-        :remove_background,
         :foreground,
         :foreground_type,
         :foreground_sizing,
         :background_cache,
         :foreground_cache,
-        :remove_foreground,
         :sponsor_id,
         :sign_ids => [],
         :scheduled_items_attributes => [

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -45,6 +45,7 @@ class Slide < ActiveRecord::Base
   validates :duration,  numericality: { greater_than_or_equal_to: 5 }
   validate  :validate_file_size, on: :update
 
+
   include SlideFormOptions
   include Schedulable
   include OwnableModel
@@ -131,6 +132,7 @@ class Slide < ActiveRecord::Base
     end
   end
 
+
   private
     def set_defaults
       # Based on http://stackoverflow.com/a/29575389/6763239.
@@ -154,20 +156,28 @@ class Slide < ActiveRecord::Base
     end
 
     def validate_video_file(type, opts = nil)
-      video = File.open(self.send("#{type}").file.path)
-
-      if video.size > 12.megabytes
-        errors.add("#{type} Video: ", 'You cannot upload a video larger than 12 MB')
+      if !self.send("#{type}").file.nil?
+        video = File.open(self.send("#{type}").file.path)
+        if video.size > 12.megabytes
+          errors.add("#{type} Video: ", 'You cannot upload a video larger than 12 MB')
+        end
+      else
+        errors.add("#{type} Video: ","You must upload a valid video file.")
       end
     end
 
     def validate_image_file(type, opts = nil)
-      file   = MiniMagick::Image.open(self.send("#{type}").file.path)
-      width  = IMAGE_DIMENSIONS[type.to_sym][:width]
-      height = IMAGE_DIMENSIONS[type.to_sym][:height]
+      if !self.send("#{type}").file.nil?
+        file   = MiniMagick::Image.open(self.send("#{type}").file.path)
+        width  = IMAGE_DIMENSIONS[type.to_sym][:width]
+        height = IMAGE_DIMENSIONS[type.to_sym][:height]
 
-      if file.width > width || file.height > height
-        errors.add("#{type} Image: ", "You cannot upload a #{type} image that is larger than #{width}x#{height}")
+        if file.width > width || file.height > height
+          errors.add("#{type} Image: ", "You cannot upload a #{type} image that is larger than #{width}x#{height}")
+        end
+      else
+        errors.add("#{type} Image: ","You must upload a valid image file.")
       end
+
     end
 end

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -4,6 +4,8 @@ class Slide < ActiveRecord::Base
     background: {width: 1920, height: 1080}
   }
   DEFAULT_DURATION = 10
+  VIDEO_EXT = ["mp4", "mp3", "mov", "avi", "qt", "asf", "flv"]
+  IMAGE_EXT = ["jpeg", "jpg", "gif", "png", "tiff", "bmp"]
 
   attr_accessor :skip_file_validation
 
@@ -156,7 +158,7 @@ class Slide < ActiveRecord::Base
     end
 
     def validate_video_file(type, media, opts = nil)
-      if !self.send("#{type}").file.nil? && media == "video"
+      if !self.send("#{type}").file.nil? && VIDEO_EXT.include?(self.send("#{type}").file.extension.downcase)
         video = File.open(self.send("#{type}").file.path)
         if video.size > 12.megabytes
           errors.add("#{type} Video: ", 'You cannot upload a video larger than 12 MB')
@@ -167,7 +169,7 @@ class Slide < ActiveRecord::Base
     end
 
     def validate_image_file(type, media, opts = nil)
-      if !self.send("#{type}").file.nil? && media == "image"
+      if !self.send("#{type}").file.nil? && IMAGE_EXT.include?(self.send("#{type}").file.extension.downcase)
         file   = MiniMagick::Image.open(self.send("#{type}").file.path)
         width  = IMAGE_DIMENSIONS[type.to_sym][:width]
         height = IMAGE_DIMENSIONS[type.to_sym][:height]

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -157,29 +157,36 @@ class Slide < ActiveRecord::Base
       end
     end
 
-    def validate_video_file(type, media, opts = nil)
-      if !self.send("#{type}").file.nil? && VIDEO_EXT.include?(self.send("#{type}").file.extension.downcase)
-        video = File.open(self.send("#{type}").file.path)
-        if video.size > 12.megabytes
-          errors.add("#{type} Video: ", 'You cannot upload a video larger than 12 MB')
-        end
-      else
-        errors.add("#{type} Video: ","You must upload a valid video file.")
+    def validate_video_file(type, opts = nil)
+      video_upload = self.send("#{type}").file
+
+      return errors.add("#{type} Video: ", "You must upload a valid video file.") unless video_upload.present?
+
+      file_ext = self.send("#{type}").file.extension.downcase
+
+      return errors.add("#{type} Video: ", "#{file_ext} video files not supported.") unless VIDEO_EXT.include?(file_ext)
+
+      video = File.open(self.send("#{type}").file.path)
+      if video.size > 12.megabytes
+        errors.add("#{type} Video: ", 'You cannot upload a video larger than 12 MB')
       end
     end
 
-    def validate_image_file(type, media, opts = nil)
-      if !self.send("#{type}").file.nil? && IMAGE_EXT.include?(self.send("#{type}").file.extension.downcase)
-        file   = MiniMagick::Image.open(self.send("#{type}").file.path)
-        width  = IMAGE_DIMENSIONS[type.to_sym][:width]
-        height = IMAGE_DIMENSIONS[type.to_sym][:height]
+    def validate_image_file(type, opts = nil)
+      image_upload = self.send("#{type}").file
 
-        if file.width > width || file.height > height
-          errors.add("#{type} Image: ", "You cannot upload a #{type} image that is larger than #{width}x#{height}")
-        end
-      else
-        errors.add("#{type} Image: ","You must upload a valid image file.")
+      return errors.add("#{type} Image: ", "You must upload a valid image file.") unless image_upload.present?
+
+      file_ext = self.send("#{type}").file.extension.downcase
+
+      return errors.add("#{type} Image: ", "#{file_ext} image files not supported.") unless IMAGE_EXT.include?(file_ext)
+
+      file   = MiniMagick::Image.open(self.send("#{type}").file.path)
+      width  = IMAGE_DIMENSIONS[type.to_sym][:width]
+      height = IMAGE_DIMENSIONS[type.to_sym][:height]
+
+      if file.width > width || file.height > height
+        errors.add("#{type} Image: ", "You cannot upload a #{type} image that is larger than #{width}x#{height}")
       end
-
     end
 end

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -147,13 +147,13 @@ class Slide < ActiveRecord::Base
 
     def validate_foreground_file
       if foreground_type.present? && foreground_type != 'none'
-        self.send("validate_#{foreground_type}_file", 'foreground', foreground_type)
+        self.send("validate_#{foreground_type}_file", 'foreground')
       end
     end
 
     def validate_background_file
       if background_type.present? && background_type != 'none'
-        self.send("validate_#{background_type}_file", 'background', background_type)
+        self.send("validate_#{background_type}_file", 'background')
       end
     end
 

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -145,18 +145,18 @@ class Slide < ActiveRecord::Base
 
     def validate_foreground_file
       if foreground_type.present? && foreground_type != 'none'
-        self.send("validate_#{foreground_type}_file", 'foreground')
+        self.send("validate_#{foreground_type}_file", 'foreground', foreground_type)
       end
     end
 
     def validate_background_file
       if background_type.present? && background_type != 'none'
-        self.send("validate_#{background_type}_file", 'background')
+        self.send("validate_#{background_type}_file", 'background', background_type)
       end
     end
 
-    def validate_video_file(type, opts = nil)
-      if !self.send("#{type}").file.nil?
+    def validate_video_file(type, media, opts = nil)
+      if !self.send("#{type}").file.nil? && media == "video"
         video = File.open(self.send("#{type}").file.path)
         if video.size > 12.megabytes
           errors.add("#{type} Video: ", 'You cannot upload a video larger than 12 MB')
@@ -166,8 +166,8 @@ class Slide < ActiveRecord::Base
       end
     end
 
-    def validate_image_file(type, opts = nil)
-      if !self.send("#{type}").file.nil?
+    def validate_image_file(type, media, opts = nil)
+      if !self.send("#{type}").file.nil? && media == "image"
         file   = MiniMagick::Image.open(self.send("#{type}").file.path)
         width  = IMAGE_DIMENSIONS[type.to_sym][:width]
         height = IMAGE_DIMENSIONS[type.to_sym][:height]

--- a/app/views/slides/_form.html.erb
+++ b/app/views/slides/_form.html.erb
@@ -137,10 +137,6 @@
                   <input class="file-path validate" type="text">
                 </div>
               </div>
-              <p>
-                <%= f.check_box :remove_background %>
-                <%= f.label :remove_background, "Remove background image" %>
-              </p>
             </div>
             <br />
             <div class="radio-button-group">
@@ -170,10 +166,6 @@
                   <input class="file-path validate" type="text">
                 </div>
               </div>
-              <p>
-                <%= f.check_box :remove_foreground %>
-                <%= f.label :remove_foreground, "Remove foreground image" %>
-              </p>
             </div>
 
             <div class="radio-button-group" data-show-when="input[name='slide[foreground_type]']==(image|video)">

--- a/test/controllers/slides_controller_test.rb
+++ b/test/controllers/slides_controller_test.rb
@@ -168,6 +168,38 @@ class SlidesControllerTest < ActionController::TestCase
     assert response.body.include?('You must upload a valid video file.')
   end
 
+  test "expects validation error when switching from video to image without uploading new file" do
+    # Arrange
+    sign_in users(:super_admin)
+    slide = slides(:video_background)
+
+    # Assume
+    assert_equal "video", slide.background_type
+
+    # Act
+    patch :update, id: slide, slide: { background_type: "image" }
+
+    # Assert
+    # can confirm background is updated to image because otherwise the error would say video
+    assert response.body.include?('You must upload a valid image file.')
+  end
+
+  test "expects validation error when switching from image to video without uploading new file" do
+    # Arrange
+    sign_in users(:super_admin)
+    slide = slides(:image_foreground)
+
+    # Assume
+    assert_equal "image", slide.foreground_type
+
+    # Act
+    patch :update, id: slide, slide: { background_type: "video" }
+
+    # Assert
+    # can confirm background is updated to video because otherwise the error would say image
+    assert response.body.include?('You must upload a valid video file.')
+  end
+
   test "confirm that foreground videos are muted and controls are displayed when previewed" do
     # Arrange
     sign_in users(:super_admin)

--- a/test/controllers/slides_controller_test.rb
+++ b/test/controllers/slides_controller_test.rb
@@ -145,18 +145,26 @@ class SlidesControllerTest < ActionController::TestCase
   end
 
   test "file must be uploaded in foreground" do
+    # Arrange
     sign_in users(:super_admin)
     slide = slides(:video_foreground)
+
+    # Act
     patch :update, id: slide, slide: { foreground: nil }
 
+    # Assert
     assert response.body.include?('You must upload a valid video file.')
   end
 
   test "file must be uploaded in background" do
+    # Arrange
     sign_in users(:super_admin)
     slide = slides(:video_background)
+
+    # Act
     patch :update, id: slide, slide: { background: nil }
 
+    # Assert
     assert response.body.include?('You must upload a valid video file.')
   end
 

--- a/test/controllers/slides_controller_test.rb
+++ b/test/controllers/slides_controller_test.rb
@@ -144,6 +144,22 @@ class SlidesControllerTest < ActionController::TestCase
     assert_equal "horizontal", slide.reload.orientation
   end
 
+  test "file must be uploaded in foreground" do
+    sign_in users(:super_admin)
+    slide = slides(:video_foreground)
+    patch :update, id: slide, slide: { foreground: nil }
+
+    assert response.body.include?('You must upload a valid video file.')
+  end
+
+  test "file must be uploaded in background" do
+    sign_in users(:super_admin)
+    slide = slides(:video_background)
+    patch :update, id: slide, slide: { background: nil }
+
+    assert response.body.include?('You must upload a valid video file.')
+  end
+
   test "confirm that foreground videos are muted and controls are displayed when previewed" do
     # Arrange
     sign_in users(:super_admin)

--- a/test/fixtures/slides.yml
+++ b/test/fixtures/slides.yml
@@ -71,3 +71,10 @@ video_background:
   menu_name: video background
   duration: 5
   background_type: video
+
+image_foreground:
+  name: image foreground
+  template: standard
+  menu_name: image foreground
+  duration: 5
+  foreground_type: image


### PR DESCRIPTION
Issue #179 
https://trello.com/c/eMyn1oug/409-defect-signage-crashes-when-a-user-chooses-a-video-or-image-for-a-slide-background-foreground-but-doesnt-upload-anything